### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ public function main() returns error? {
 
 ## Examples
 
-The `HubSpot CRM Commerce Quotes` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/module-ballerinax-hubspot.crm.commerce.quotes/tree/main/examples/), covering the following use cases:
+The `HubSpot CRM Commerce Quotes` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes/tree/main/examples/), covering the following use cases:
 
 1. [Sales Analytics System](./sales_analytics/) - A store can insert their quotes to the system, and system record and analyses the details on the quotes.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.commerce.quotes.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.commerce.quotes)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.commerce.quotes.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.commerce.quotes)
 
 ## Overview
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -193,6 +193,6 @@ public function main() returns error? {
 
 ## Examples
 
-The `HubSpot CRM Commerce Quotes` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/module-ballerinax-hubspot.crm.commerce.quotes/tree/main/examples/), covering the following use cases:
+The `HubSpot CRM Commerce Quotes` connector provides practical examples illustrating usage in various scenarios. Explore these [examples](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes/tree/main/examples/), covering the following use cases:
 
 1. [Sales Analytics System](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.quotes/tree/main/examples/sales-analytics) - A store can insert their quotes to the system, and system record and analyses the details on the quotes.


### PR DESCRIPTION
## Purpose

Fixes documentation issues identified in the HubSpot connector audit. This PR addresses the GitHub Issues badge URL in the top-level `README.md`, where the label segment was missing the `%2F` (encoded slash) and rendered as a malformed link.

Changes:

- Fix encoding in the GitHub Issues badge URL (`module%hubspot.crm.commerce.quotes` -> `module%2Fhubspot.crm.commerce.quotes`).

Notes on systemic fixes that did NOT apply to this repo:

- `Hubspot` mis-casing: the only `Hubspot` occurrences are inside image alt-text (e.g., `![Hubspot developer testacc1]`), which the spec explicitly excludes from the brand-name correction. No edit made.
- `ave` typo: not present in either README.
- Duplicated `Ballerina` / redundant `Connector` in title: the title is already canonical (`# Ballerina HubSpot CRM Commerce Quotes connector`).

## Examples

N/A - documentation-only change.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility

Refs ballerina-platform/ballerina-library#8823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request corrects documentation issues in the HubSpot CRM Commerce Quotes connector across two README files.

**Changes made:**

1. **Top-level README.md**: Fixed the GitHub Issues badge URL by correcting the label encoding from `module%hubspot.crm.commerce.quotes` to `module%2Fhubspot.crm.commerce.quotes`, ensuring the link resolves correctly. Additionally updated the "Explore these examples" link to reference the correct repository path with the `ballerina-platform/` prefix.

2. **ballerina/README.md**: Updated the Examples section link to reference the correct repository path by adding the `ballerina-platform/` prefix.

These changes resolve broken links and ensure users are directed to the correct resources when accessing documentation. This is a documentation-only update with no changes to code, tests, or specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->